### PR TITLE
Releases policy change COPS-863

### DIFF
--- a/combined_docs.md
+++ b/combined_docs.md
@@ -1162,6 +1162,8 @@ datica -E "<your_env_alias>" redeploy app01
 
 The `releases` command allows you to manage your code service releases. A release is automatically created each time you perform a git push. The release is tagged with the git SHA of the commit. Releases are a way of tagging specific points in time of your git history. You can rollback to a specific release by using the [rollback](#rollback) command. The releases command cannot be run directly but has sub commands.
 
+By default, the last three releases will be kept.  Please contact Support if you require more than the last three releases to be retained
+
 ## Releases List
 
 ```


### PR DESCRIPTION
The registry grows fast when we retain all releases.  We should have a policy declaring how many releases we will keep.